### PR TITLE
fix: exclude lib/ from Biome checks to unblock Renovate PRs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "files": {
+    "includes": ["**", "!**/lib"]
+  },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
@@ -12,13 +15,13 @@
         "noExplicitAny": "off"
       }
     },
-    "includes": ["**", "!**/lib/**"]
+    "includes": ["**", "!**/lib"]
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
-    "includes": ["**", "!**/lib/**"]
+    "includes": ["**", "!**/lib"]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Summary

- Biome v2の `assist` セクション（organizeImports）が `lib/` ディレクトリを除外していなかったため、`npm run build` 実行後の `check-code-quality` CI が `.d.ts` 生成ファイルのフォーマットエラーで失敗していた
- トップレベルの `files.includes` で `lib/` を除外することで、linter/formatter/assist 全てに適用されるようにした
- あわせて `$schema` のバージョンをインストール済みの Biome バージョン (2.4.16) に更新

## 影響

このPRがマージされると、以下のRenovate/DependabotのPR (9件) がマージ可能になります：

- #429 sentry v10.57.0
- #440 typescript v6 (要別途確認)
- #450 @slack/bolt v4.7.3
- #462 lint-staged v17 (要別途確認)
- #466 brace-expansion (security)
- #469 Node.js v24.16.0
- #470 ws 8.18→8.21 (security)
- #471 qs 6.15.0→6.15.2 (security)
- #475 axios 1.13.6→1.17.0

## Root Cause

```
lib/eventHandlers/reactionAddedHandlers/checked.d.ts:2:1 assist/source/organizeImports
× Some imports or exports are not organized.
```

Biome v2では `linter.includes` と `formatter.includes` に `!**/lib` を指定しても、`assist` セクションには適用されない。`files.includes` を使うことで全セクションに適用できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01CwsHEGaU4tzWia6eXD7BYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwsHEGaU4tzWia6eXD7BYv)_