### PR TITLE
fix: add rootDir to tsconfig for TypeScript v6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
+    "rootDir": "./src",
     "outDir": "./lib",
     "jsx": "react-jsx",
     "jsxImportSource": "jsx-slack",


### PR DESCRIPTION
## Summary

TypeScript v6 now requires `rootDir` to be explicitly set in `tsconfig.json` when `outDir` is configured. Without it, `tsc` fails with:

```
error TS5011: The common source directory of 'tsconfig.json' is './src'.
The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
Visit https://aka.ms/ts6 for migration information.
```

This change adds `"rootDir": "./src"` which matches the existing `"include": ["src/**/*"]` pattern.

## Impact

This fixes `check-code-quality` CI failures on:
- Renovate PR #440 (update TypeScript to v6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EydGyq7gPdRj8TjpA4BGkg)_