### PR TITLE
fix: exclude test files from tsconfig to fix TypeScript v6 build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "skipLibCheck": true,
     "typeRoots": ["src/types", "node_modules/@types"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "!src/**/*.test.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- **`tsconfig.json`**: Add `!src/**/*.test.ts` to `include` to exclude test files from the main build. TypeScript v6 compiles all files matching `src/**/*` including test files, but jest globals aren't declared in the main build — causing `TS2593: Cannot find name 'test'`. Unblocks PR #440.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EydGyq7gPdRj8TjpA4BGkg)_