### PR TITLE
fix: resolve TypeScript CI failures in jest test compilation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   roots: ["<rootDir>/src"],
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.tsx?$": ["ts-jest", { tsconfig: "tsconfig.test.json" }],
   },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   moduleFileExtensions: ["ts", "js"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "skipLibCheck": true,
     "typeRoots": ["src/types", "node_modules/@types"]
   },
-  "include": ["src/**/*", "!src/**/*.test.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## 問題

Renovate PRs (#487, #490) および PR #493 で CI が以下のエラーで失敗していました：

```
src/eventHandlers/reactionAddedHandlers/checked.test.ts:3:1 - error TS2593: Cannot find name 'test'. Do you need to install type definitions for a test runner?
```

## 根本原因

2つの問題が重なっていました：

1. **tsconfig.json の include negation パターンが機能しない**: `"include": ["src/**/*", "!src/**/*.test.ts"]` の `!` による除外パターンは TypeScript の `include` 配列では無視される（サポートされていない）
2. **ts-jest が jest global 型を検出できない**: ts-jest でテストファイルをコンパイルする際、`@types/jest` の型が正しく読み込まれず、`test`/`describe`/`expect` 等のグローバルが未定義になる

## 修正内容

- **`tsconfig.json`**: `include` の否定パターンを削除し、`exclude` 配列でテストファイルを除外（ビルド用）
- **`tsconfig.test.json`** (新規): jest/ts-jest 専用の TypeScript 設定。`types: ["jest", "node"]` を明示することで jest グローバル型を保証
- **`jest.config.js`**: ts-jest のトランスフォームで `tsconfig.test.json` を使用するよう設定

## 影響

この PR がマージされると、Renovate PRs #487 と #490 の CI が通るようになります（それぞれ rebase または再実行が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011GwuectXyGe46Xtds8vdGh

---
_Generated by [Claude Code](https://claude.ai/code/session_011GwuectXyGe46Xtds8vdGh)_