### PR TITLE
fix: properly exclude test files from TypeScript compilation

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "files": {
     "includes": ["**", "!**/lib"]
   },


### PR DESCRIPTION
TypeScript's `include` array does not support negation patterns (e.g., `!src/**/*.test.ts`).
Test files must be excluded using the `exclude` array instead.

This caused `tsc` to compile test files and fail with TS2593 because
`@types/jest` global types (like `test`) were not available in the
production compilation context.